### PR TITLE
Bug fixes

### DIFF
--- a/lua/hologram/image.lua
+++ b/lua/hologram/image.lua
@@ -3,7 +3,7 @@ local magick = require('hologram.magick')
 
 local image = {}
 
-local stdout = vim.loop.new_pipe()
+local stdout = vim.loop.new_pipe(false)
 stdout:open(1)
 
 local Image = {}

--- a/lua/hologram/image.lua
+++ b/lua/hologram/image.lua
@@ -207,9 +207,9 @@ function image.read_source(source)
     local file, error = io.open(source, 'r')
 
     if not file then
-		vim.api.nvim_err_writeln("Unable to open image file: " .. error)
-		return
-	end
+        vim.api.nvim_err_writeln("Unable to open image file: " .. error)
+        return
+    end
 
     local raw = file:read('*all')
     io.close(file)

--- a/lua/hologram/image.lua
+++ b/lua/hologram/image.lua
@@ -204,7 +204,13 @@ end
 
 function image.read_source(source)
     -- TODO: if source is url, create tempfile
-    local file = io.open(source, 'r')
+    local file, error = io.open(source, 'r')
+
+    if not file then
+		vim.api.nvim_err_writeln("Unable to open image file: " .. error)
+		return
+	end
+
     local raw = file:read('*all')
     io.close(file)
     raw = utils.base64_encode(raw)


### PR DESCRIPTION
This small PR fixes an error that may occur on certain neovim versions when `new_pipe` is invoked without arguments.
Also added some more intuitive error handling when an image cannot be located. Although it's not an ideal fix yet, it should at least give users an idea of what's going on :)