### PR TITLE
Fix: make it work for larger images

### DIFF
--- a/lua/hologram/init.lua
+++ b/lua/hologram/init.lua
@@ -83,7 +83,7 @@ end
 function hologram.update_images(buf)
     if buf == 0 then buf = vim.api.nvim_get_current_buf() end
 
-    for _, ext_loc in ipairs(hologram.get_ext_loclist()) do
+    for _, ext_loc in ipairs(hologram.get_ext_loclist(0)) do
         local ext, _, _ = unpack(ext_loc)
 
         local img = hologram.get_image(buf, ext)


### PR DESCRIPTION
Closes #7
Closes #5 (I think?)

This PR fixes one error when calling `hologram.get_ext_loclist`, and fixes the transmission code for larger files.


![Screenshot from 2022-02-12 18-49-51](https://user-images.githubusercontent.com/1423607/153732596-e2c58f35-fb69-4a7e-aa06-6fc5047b7781.png)

Reference: https://sw.kovidgoyal.net/kitty/graphics-protocol/#remote-client