### PR TITLE
fix: allow relative paths

### DIFF
--- a/lua/hologram/init.lua
+++ b/lua/hologram/init.lua
@@ -96,10 +96,31 @@ function hologram.find_source(line)
         local inline_link = line:match('!%[.-%]%(.-%)')
         if inline_link then
             local source = inline_link:match('%((.+)%)')
-            if fs.check_sig_PNG(source) then
-                return source
+            local path = hologram._to_absolute_path(source)
+            if fs.check_sig_PNG(path) then
+                return path
             else return nil end
         end
+    end
+end
+
+function hologram._to_absolute_path(path)
+    if hologram._is_root_path(path) then
+        return path
+    else
+        -- absolute_path: folder_path + relative_path
+        local folder_path = vim.fn.expand("%:p:h")
+        local absolute_path = folder_path .. "/" .. path
+        return absolute_path
+    end
+end
+
+function hologram._is_root_path(path)
+    local first_path_char = string.sub(path, 0, 1)
+    if first_path_char == "/" then
+      return true
+    else
+      return false
     end
 end
 


### PR DESCRIPTION
Turn relative paths to images into absolute paths so they're picked up by the plugin.
Tried using the library [plenary.path](https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/path.lua), but didn't work out for cases where the vim current working directory wasn't the same as the directory where the mardown file is located (i.e. you've opened vim at the project root, and you're accessing a file under a subdirectory).