### PR TITLE
fix: wrong ANSI code for moving cursor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+[*.lua]
+# [basic]
+
+# optional space/tab
+indent_style = space
+# if indent_style is space, this is valid
+indent_size = 4
+# if indent_style is tab, this is valid
+tab_width = 4
+# none/single/double
+quote_style = single
+
+continuation_indent = 4
+
+# [operator space]
+space_around_math_operator = true
+
+space_around_table_field_list = false
+
+# this mean utf8 length , if this is 'unset' then the line width is no longer checked
+# this option decides when to chopdown the code
+max_line_length = 120
+
+# optional crlf/lf/cr/auto, if it is 'auto', in windows it is crlf other platforms are lf
+# in neovim the value 'auto' is not a valid option, please use 'unset' 
+end_of_line = lf

--- a/lua/hologram/base64.lua
+++ b/lua/hologram/base64.lua
@@ -1,4 +1,4 @@
--- LuaJIT FFI Base64 encoder/decoder 
+-- LuaJIT FFI Base64 encoder/decoder
 -- Copyright (c) 2022 Edward Lufadeju (edward@ncade.com)
 -- See end of file for license information
 
@@ -6,35 +6,35 @@ local ffi = require('ffi')
 local base64 = {}
 
 local b64 = ffi.new('unsigned const char[65]',
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')
 
 function base64.encode(str)
     local band, bor, lsh, rsh = bit.band, bit.bor, bit.lshift, bit.rshift
     local len = #str
     local enc_len = 4 * math.ceil(len / 3) -- (len + 2) // 3 * 4 after Lua 5.3
 
-    local src = ffi.new('unsigned const char[?]', len+1, str)
-    local enc = ffi.new('unsigned char[?]', enc_len+1)
+    local src = ffi.new('unsigned const char[?]', len + 1, str)
+    local enc = ffi.new('unsigned char[?]', enc_len + 1)
 
     local i, j = 0, 0
-    while i < len-2 do
+    while i < len - 2 do
         enc[j] = b64[band(rsh(src[i], 2), 0x3F)]
-        enc[j+1] = b64[bor(lsh(band(src[i], 0x3), 4), rsh(band(src[i+1], 0xF0), 4))]
-        enc[j+2] = b64[bor(lsh(band(src[i+1], 0xF), 2), rsh(band(src[i+2], 0xC0), 6))]
-        enc[j+3] = b64[band(src[i+2], 0x3F)]
-        i, j = i+3, j+4
+        enc[j + 1] = b64[bor(lsh(band(src[i], 0x3), 4), rsh(band(src[i + 1], 0xF0), 4))]
+        enc[j + 2] = b64[bor(lsh(band(src[i + 1], 0xF), 2), rsh(band(src[i + 2], 0xC0), 6))]
+        enc[j + 3] = b64[band(src[i + 2], 0x3F)]
+        i, j = i + 3, j + 4
     end
 
     if i < len then
         enc[j] = b64[band(rsh(src[i], 2), 0x3F)]
-        if i == len-1 then
-            enc[j+1] = b64[lsh(band(src[i], 0x3), 4)]
-            enc[j+2] = 0x3D
+        if i == len - 1 then
+            enc[j + 1] = b64[lsh(band(src[i], 0x3), 4)]
+            enc[j + 2] = 0x3D
         else
-            enc[j+1] = b64[bor(lsh(band(src[i], 0x3), 4), rsh(band(src[i+1], 0xF0), 4))]
-            enc[j+2] = b64[lsh(band(src[i+1], 0xF), 2)]
+            enc[j + 1] = b64[bor(lsh(band(src[i], 0x3), 4), rsh(band(src[i + 1], 0xF0), 4))]
+            enc[j + 2] = b64[lsh(band(src[i + 1], 0xF), 2)]
         end
-        enc[j+3] = 0x3D
+        enc[j + 3] = 0x3D
     end
 
     return ffi.string(enc, enc_len)

--- a/lua/hologram/fs.lua
+++ b/lua/hologram/fs.lua
@@ -8,8 +8,8 @@ function fs.get_dims_PNG(path)
         assert(vim.loop.fs_read(fd, 24, 0)))
     assert(vim.loop.fs_close(fd))
 
-    local width = fs.bytes2int(buf+16)
-    local height = fs.bytes2int(buf+20)
+    local width = fs.bytes2int(buf + 16)
+    local height = fs.bytes2int(buf + 20)
     return width, height
 end
 
@@ -20,27 +20,27 @@ function fs.check_sig_PNG(path)
     local sig = ffi.new('const unsigned char[?]', 9,
         assert(vim.loop.fs_read(fd, 8, 0)))
 
-    return sig[0]==137 and sig[1]==80
-        and sig[2]==78 and sig[3]==71
-        and sig[4]==13 and sig[5]==10
-        and sig[6]==26 and sig[7]==10
+    return sig[0] == 137 and sig[1] == 80
+        and sig[2] == 78 and sig[3] == 71
+        and sig[4] == 13 and sig[5] == 10
+        and sig[6] == 26 and sig[7] == 10
 end
 
 function fs.get_chunked(buf)
     local len = ffi.sizeof(buf)
     local i, j, chunks = 0, 0, {}
-    while i < len-4096 do
-        chunks[j] = ffi.string(buf+i, 4096)
-        i, j = i+4096, j+1
+    while i < len - 4096 do
+        chunks[j] = ffi.string(buf + i, 4096)
+        i, j = i + 4096, j + 1
     end
-    chunks[j] = ffi.string(buf+i)
+    chunks[j] = ffi.string(buf + i)
     return chunks
 end
 
 -- big endian
 function fs.bytes2int(bufp)
     local bor, lsh = bit.bor, bit.lshift
-    return bor(lsh(bufp[0],24), lsh(bufp[1],16), lsh(bufp[2],8), bufp[3])
+    return bor(lsh(bufp[0], 24), lsh(bufp[1], 16), lsh(bufp[2], 8), bufp[3])
 end
 
 return fs

--- a/lua/hologram/fs.lua
+++ b/lua/hologram/fs.lua
@@ -2,6 +2,9 @@ local ffi = require('ffi')
 local base64 = require('hologram.base64')
 local fs = {}
 
+---@param path string
+---@return integer
+---@return integer
 function fs.get_dims_PNG(path)
     local fd = assert(vim.loop.fs_open(path, 'r', 438))
     local buf = ffi.new('const unsigned char[?]', 25,
@@ -13,6 +16,8 @@ function fs.get_dims_PNG(path)
     return width, height
 end
 
+---@param path string
+---@return boolean? # returns nil on error
 function fs.check_sig_PNG(path)
     local fd = vim.loop.fs_open(path, 'r', 438)
     if fd == nil then return end

--- a/lua/hologram/image.lua
+++ b/lua/hologram/image.lua
@@ -12,20 +12,20 @@ Image.__index = Image
 -- TODO: proper type definition
 ---@alias TransmissionType string
 
----@class Keys
+---@class NewImageArgs
 ---@field format integer
 ---@field transmission_type TransmissionType
 ---@field data_width integer
 ---@field data_height integer
----@field data_size integer
----@field data_offset integer
----@field image_number integer
----@field compressed integer
----@field image_id integer
----@field placement_id integer
+---@field data_size integer?
+---@field data_offset integer?
+---@field image_number integer?
+---@field compressed integer?
+---@field image_id integer?
+---@field placement_id integer?
 
 ---@param source string
----@param keys Keys
+---@param keys NewImageArgs
 ---@return unknown
 function Image:new(source, keys)
     keys = keys or {}
@@ -72,10 +72,22 @@ function Image:new(source, keys)
     return Image.instances[keys.image_id]
 end
 
+---@class DisplayArgs
+---@field x_offset integer?
+---@field y_offset integer?
+---@field width integer?
+---@field height integer?
+---@field cell_x integer?
+---@field cell_y integer?
+---@field cols integer?
+---@field rows integer?
+---@field z_index integer?
+---@field placement_id integer?
+
 ---@param row integer
 ---@param col integer
 ---@param buf integer buffer number
----@param keys Keys
+---@param keys DisplayArgs
 ---@return boolean
 function Image:display(row, col, buf, keys)
     keys = keys or {}

--- a/lua/hologram/image.lua
+++ b/lua/hologram/image.lua
@@ -35,8 +35,8 @@ function Image:new(source, keys)
             keys.data_width, keys.data_height = fs.get_dims_PNG(source)
         end
     end
-    local cols = math.ceil(keys.data_width/state.cell_size.x)
-    local rows = math.ceil(keys.data_height/state.cell_size.y)
+    local cols = math.ceil(keys.data_width / state.cell_size.x)
+    local rows = math.ceil(keys.data_height / state.cell_size.y)
 
     keys.action = 't'
     keys.quiet = 2
@@ -86,9 +86,9 @@ function Image:display(row, col, buf, keys)
         local y_offset = 0
 
         -- resize
-        local winwidth = (info.width-info.textoff)
+        local winwidth = (info.width - info.textoff)
         if cols > winwidth then
-            rows = winwidth * (rows/cols)
+            rows = winwidth * (rows / cols)
             cols = winwidth
         end
         local row_factor = self.rows / rows
@@ -97,14 +97,14 @@ function Image:display(row, col, buf, keys)
         self:set_vpad(buf, row, info.width, math.ceil(rows))
 
         -- check if visible
-        if row < info.topline-1 or row > info.botline then
+        if row < info.topline - 1 or row > info.botline then
             return false
         end
 
         -- image is cut off top
-        if row == info.topline-1 then
+        if row == info.topline - 1 then
             local topfill = vim.fn.winsaveview().topfill
-            local cutoff_rows = math.max(0, rows-topfill)
+            local cutoff_rows = math.max(0, rows - topfill)
             y_offset = cutoff_rows * row_factor * cs.y
             rows = topfill
         end
@@ -112,8 +112,8 @@ function Image:display(row, col, buf, keys)
         -- image is cut off bottom
         if row == info.botline then
             local screen_row = utils.buf_screenpos(row, 0, win, buf)
-            local screen_winbot = info.winrow+info.height
-            local visible_rows = screen_winbot-screen_row
+            local screen_winbot = info.winrow + info.height
+            local visible_rows = screen_winbot - screen_row
             if visible_rows > 0 then
                 rows = visible_rows
                 height = visible_rows * row_factor * cs.y
@@ -172,26 +172,26 @@ function Image:delete(buf, opts)
 end
 
 function Image:set_vpad(buf, row, cols, rows)
-    if self.vpad ~= nil and 
-        self.vpad.row == row and 
-        self.vpad.cols == cols and 
+    if self.vpad ~= nil and
+        self.vpad.row == row and
+        self.vpad.cols == cols and
         self.vpad.rows == rows then
         return
     end
 
     local text = string.rep(' ', cols)
     local filler = {}
-    for i=0,rows-1 do
-        filler[#filler+1] = {{text, ''}}
+    for _ = 0, rows - 1 do
+        filler[#filler + 1] = {{text, ''}}
     end
 
-    vim.api.nvim_buf_set_extmark(buf, vim.g.hologram_extmark_ns, row-1, 0, {
+    vim.api.nvim_buf_set_extmark(buf, vim.g.hologram_extmark_ns, row - 1, 0, {
         id = self.transmit_keys.image_id,
         virt_lines = filler,
         --virt_lines_leftcol = true,
     })
 
-    self.vpad = {row=row, cols=cols, rows=rows}
+    self.vpad = {row = row, cols = cols, rows = rows}
 end
 
 function Image:remove_vpad(buf)

--- a/lua/hologram/image.lua
+++ b/lua/hologram/image.lua
@@ -9,6 +9,24 @@ local Image = {
 }
 Image.__index = Image
 
+-- TODO: proper type definition
+---@alias TransmissionType string
+
+---@class Keys
+---@field format integer
+---@field transmission_type TransmissionType
+---@field data_width integer
+---@field data_height integer
+---@field data_size integer
+---@field data_offset integer
+---@field image_number integer
+---@field compressed integer
+---@field image_id integer
+---@field placement_id integer
+
+---@param source string
+---@param keys Keys
+---@return unknown
 function Image:new(source, keys)
     keys = keys or {}
     keys = vim.tbl_extend('keep', keys, {
@@ -54,6 +72,11 @@ function Image:new(source, keys)
     return Image.instances[keys.image_id]
 end
 
+---@param row integer
+---@param col integer
+---@param buf integer buffer number
+---@param keys Keys
+---@return boolean
 function Image:display(row, col, buf, keys)
     keys = keys or {}
     keys = vim.tbl_extend('keep', keys, {
@@ -151,6 +174,8 @@ function Image:display(row, col, buf, keys)
     return true
 end
 
+---@param buf integer buffer number
+---@param opts {free: boolean?}
 function Image:delete(buf, opts)
     opts = opts or {}
     opts = vim.tbl_extend('keep', opts, {
@@ -171,6 +196,10 @@ function Image:delete(buf, opts)
     end
 end
 
+---@param buf integer buffer number
+---@param row integer
+---@param cols integer
+---@param rows integer
 function Image:set_vpad(buf, row, cols, rows)
     if self.vpad ~= nil and
         self.vpad.row == row and
@@ -194,6 +223,7 @@ function Image:set_vpad(buf, row, cols, rows)
     self.vpad = {row = row, cols = cols, rows = rows}
 end
 
+---@param buf integer buffer number
 function Image:remove_vpad(buf)
     if self.vpad ~= nil then
         vim.api.nvim_buf_del_extmark(buf, vim.g.hologram_extmark_ns, self.transmit_keys.image_id)

--- a/lua/hologram/init.lua
+++ b/lua/hologram/init.lua
@@ -46,15 +46,15 @@ local prev_ids = {}
 function hologram.buf_render_images(buf, top, bot)
     local exts = vim.api.nvim_buf_get_extmarks(buf,
         vim.g.hologram_extmark_ns,
-        {math.max(top-1, 0), 0}, 
-        {bot-2, -1},
-    {})
+        {math.max(top - 1, 0), 0},
+        {bot - 2, -1},
+        {})
 
     local curr_ids = {}
     for _, ext in ipairs(exts) do
         local id, row, col = unpack(ext)
-        Image.instances[id]:display(row+1, 0, buf, {})
-        curr_ids[#curr_ids+1] = id
+        Image.instances[id]:display(row + 1, 0, buf, {})
+        curr_ids[#curr_ids + 1] = id
     end
 
     if prev_ids[buf] ~= nil then
@@ -73,7 +73,7 @@ function hologram.buf_generate_images(buf, top, bot)
         local source = hologram.find_source(line)
         if source ~= nil then
             local img = Image:new(source, {})
-            img:display(top+n, 0, buf, {})
+            img:display(top + n, 0, buf, {})
         end
     end
 end
@@ -83,11 +83,11 @@ function hologram.buf_delete_images(buf, top, bot)
         vim.g.hologram_extmark_ns,
         {top, 0},
         {bot, -1},
-    {})
+        {})
 
     for _, ext in ipairs(exts) do
         local id, _, _ = unpack(ext)
-        Image.instances[id]:delete(buf, {free=true})
+        Image.instances[id]:delete(buf, {free = true})
     end
 end
 
@@ -99,7 +99,9 @@ function hologram.find_source(line)
             local path = hologram._to_absolute_path(source)
             if fs.check_sig_PNG(path) then
                 return path
-            else return nil end
+            else
+                return nil
+            end
         end
     end
 end
@@ -109,18 +111,18 @@ function hologram._to_absolute_path(path)
         return path
     else
         -- absolute_path: folder_path + relative_path
-        local folder_path = vim.fn.expand("%:p:h")
-        local absolute_path = folder_path .. "/" .. path
+        local folder_path = vim.fn.expand('%:p:h')
+        local absolute_path = folder_path .. '/' .. path
         return absolute_path
     end
 end
 
 function hologram._is_root_path(path)
     local first_path_char = string.sub(path, 0, 1)
-    if first_path_char == "/" then
-      return true
+    if first_path_char == '/' then
+        return true
     else
-      return false
+        return false
     end
 end
 

--- a/lua/hologram/init.lua
+++ b/lua/hologram/init.lua
@@ -3,6 +3,9 @@ local state = require('hologram.state')
 local Image = require('hologram.image')
 local fs = require('hologram.fs')
 
+---@class HologramSetupOpts
+---@field auto_display boolean?
+
 function hologram.setup(opts)
     -- Create autocommands
     local augroup = vim.api.nvim_create_augroup('Hologram', {clear = false})
@@ -43,6 +46,9 @@ end
 
 local prev_ids = {}
 
+---@param buf integer buffer number
+---@param top integer
+---@param bot integer
 function hologram.buf_render_images(buf, top, bot)
     local exts = vim.api.nvim_buf_get_extmarks(buf,
         vim.g.hologram_extmark_ns,
@@ -67,6 +73,9 @@ function hologram.buf_render_images(buf, top, bot)
     prev_ids[buf] = curr_ids
 end
 
+---@param buf integer buffer number
+---@param top integer
+---@param bot integer
 function hologram.buf_generate_images(buf, top, bot)
     local lines = vim.api.nvim_buf_get_lines(buf, top, bot, false)
     for n, line in ipairs(lines) do
@@ -78,6 +87,9 @@ function hologram.buf_generate_images(buf, top, bot)
     end
 end
 
+---@param buf integer buffer number
+---@param top integer
+---@param bot integer
 function hologram.buf_delete_images(buf, top, bot)
     local exts = vim.api.nvim_buf_get_extmarks(buf,
         vim.g.hologram_extmark_ns,
@@ -91,6 +103,8 @@ function hologram.buf_delete_images(buf, top, bot)
     end
 end
 
+---@param line string
+---@return string? path absolute path to the image if it is valid
 function hologram.find_source(line)
     if line:find('png') then
         local inline_link = line:match('!%[.-%]%(.-%)')
@@ -106,6 +120,8 @@ function hologram.find_source(line)
     end
 end
 
+---@param path string
+---@return string
 function hologram._to_absolute_path(path)
     if hologram._is_root_path(path) then
         return path
@@ -117,6 +133,8 @@ function hologram._to_absolute_path(path)
     end
 end
 
+---@param path string
+---@return boolean
 function hologram._is_root_path(path)
     local first_path_char = string.sub(path, 0, 1)
     if first_path_char == '/' then

--- a/lua/hologram/state.lua
+++ b/lua/hologram/state.lua
@@ -14,7 +14,7 @@ state.screen_size = {
 
 function state.update_cell_size()
     local ffi = require('ffi')
-    ffi.cdef[[
+    ffi.cdef [[
         typedef struct {
             unsigned short row;
             unsigned short col;
@@ -34,7 +34,7 @@ function state.update_cell_size()
         TIOCGWINSZ = 0x40087468
     end
 
-    local sz = ffi.new("winsize")
+    local sz = ffi.new('winsize')
     assert(ffi.C.ioctl(1, TIOCGWINSZ, sz) == 0,
         'Hologram failed to get screen size: detected OS is not supported.')
 

--- a/lua/hologram/terminal.lua
+++ b/lua/hologram/terminal.lua
@@ -14,7 +14,7 @@ local stdout = vim.loop.new_tty(1, false)
 
      (*) Lua5.1/LuaJIT accepts escape seq. in dec or hex form (not octal).
 ]]
-   --
+--
 
 local CTRL_KEYS = {
 	-- General
@@ -58,7 +58,7 @@ function terminal.send_graphics_command(keys, payload)
 			ctrl = ctrl .. CTRL_KEYS[k] .. '=' .. v .. ','
 		end
 	end
-	ctrl = ctrl:sub(0, -2)  -- chop trailing comma
+	ctrl = ctrl:sub(0, -2) -- chop trailing comma
 
 	if payload then
 		if keys.transmission_type ~= 'd' then
@@ -108,7 +108,11 @@ end
 
 -- glob together writes to stdout
 terminal.write = vim.schedule_wrap(function(data)
-	stdout:write(data)
+	if stdout then
+		stdout:write(data)
+	else
+		vim.notify('failed to get tty via vim.loop.new_tty()', vim.log.levels.ERROR)
+	end
 end)
 
 return terminal

--- a/lua/hologram/terminal.lua
+++ b/lua/hologram/terminal.lua
@@ -13,90 +13,102 @@ local stdout = vim.loop.new_tty(1, false)
               <ESC> - \x1b or \27 (*)
 
      (*) Lua5.1/LuaJIT accepts escape seq. in dec or hex form (not octal).
-]]--
+]]
+   --
 
 local CTRL_KEYS = {
-    -- General
-    action = 'a',
-    delete_action = 'd',
-    quiet = 'q',
+	-- General
+	action = 'a',
+	delete_action = 'd',
+	quiet = 'q',
 
-    -- Transmission
-    format = 'f',
-    transmission_type = 't',
-    data_width = 's',
-    data_height = 'v',
-    data_size = 'S',
-    data_offset = 'O',
-    image_id = 'i',
-    image_number = 'I',
-    compressed = 'o',
-    more = 'm',
+	-- Transmission
+	format = 'f',
+	transmission_type = 't',
+	data_width = 's',
+	data_height = 'v',
+	data_size = 'S',
+	data_offset = 'O',
+	image_id = 'i',
+	image_number = 'I',
+	compressed = 'o',
+	more = 'm',
 
-    -- Display
-    placement_id = 'p',
-    x_offset = 'x',
-    y_offset = 'y',
-    width = 'w',
-    height = 'h',
-    cell_x_offset = 'X',
-    cell_y_offset = 'Y',
-    cols = 'c',
-    rows = 'r',
-    cursor_movement = 'C',
-    z_index = 'z',
+	-- Display
+	placement_id = 'p',
+	x_offset = 'x',
+	y_offset = 'y',
+	width = 'w',
+	height = 'h',
+	cell_x_offset = 'X',
+	cell_y_offset = 'Y',
+	cols = 'c',
+	rows = 'r',
+	cursor_movement = 'C',
+	z_index = 'z',
 
-    -- TODO: Animation
+	-- TODO: Animation
 }
 
 function terminal.send_graphics_command(keys, payload)
-    if payload and string.len(payload) > 4096 then keys.more = 1 else keys.more = 0 end
-    local ctrl = ''
-    for k, v in pairs(keys) do
-        if v ~= nil then
-            ctrl = ctrl..CTRL_KEYS[k]..'='..v..','
-        end
-    end
-    ctrl = ctrl:sub(0, -2) -- chop trailing comma
+	if payload and string.len(payload) > 4096 then keys.more = 1 else keys.more = 0 end
+	local ctrl = ''
+	for k, v in pairs(keys) do
+		if v ~= nil then
+			ctrl = ctrl .. CTRL_KEYS[k] .. '=' .. v .. ','
+		end
+	end
+	ctrl = ctrl:sub(0, -2)  -- chop trailing comma
 
-    if payload then
-        if keys.transmission_type ~= 'd' then
-            payload = base64.encode(payload)
-        end
-        payload = terminal.get_chunked(payload)
-        for i=1,#payload do
-            terminal.write('\x1b_G'..ctrl..';'..payload[i]..'\x1b\\')
-            if i == #payload-1 then ctrl = 'm=0' else ctrl = 'm=1' end
-        end
-    else
-        terminal.write('\x1b_G'..ctrl..'\x1b\\')
-    end
+	if payload then
+		if keys.transmission_type ~= 'd' then
+			payload = base64.encode(payload)
+		end
+		payload = terminal.get_chunked(payload)
+		for i = 1, #payload do
+			terminal.write('\x1b_G' .. ctrl .. ';' .. payload[i] .. '\x1b\\')
+			if i == #payload - 1 then ctrl = 'm=0' else ctrl = 'm=1' end
+		end
+	else
+		terminal.write('\x1b_G' .. ctrl .. '\x1b\\')
+	end
+end
+
+---@param payload any
+function terminal.send_sixel_command(keys, payload)
+	if payload and string.len(payload) > 4086 then keys.more = 1 else keys.more = 0 end
+	local ctrl = ''
+	for k, v in pairs(keys) do
+		if v ~= nil then
+			ctrl = ctrl .. CTRL_KEYS[k] .. '=' .. v .. ','
+		end
+	end
 end
 
 -- Split into chunks of max 4096 length
 function terminal.get_chunked(str)
-    local chunks = {}
-    for i = 1,#str,4096 do
-        local chunk = str:sub(i, i + 4096 - 1):gsub('%s', '')
-        if #chunk > 0 then
-            table.insert(chunks, chunk)
-        end
-    end
-    return chunks
+	local chunks = {}
+	for i = 1, #str, 4096 do
+		local chunk = str:sub(i, i + 4096 - 1):gsub('%s', '')
+		if #chunk > 0 then
+			table.insert(chunks, chunk)
+		end
+	end
+	return chunks
 end
 
 function terminal.move_cursor(row, col)
-    terminal.write('\x1b[s')
-    terminal.write('\x1b['..row..';'..col..'H')
+	terminal.write('\x1b[s')
+	terminal.write('\x1b[' .. row .. ';' .. col .. 'H')
 end
 
 function terminal.restore_cursor()
-    terminal.write('\x1b[u')
+	terminal.write('\x1b[u')
 end
 
 -- glob together writes to stdout
 terminal.write = vim.schedule_wrap(function(data)
-    stdout:write(data)
+	stdout:write(data)
 end)
 
 return terminal

--- a/lua/hologram/terminal.lua
+++ b/lua/hologram/terminal.lua
@@ -87,7 +87,7 @@ end
 
 function terminal.move_cursor(row, col)
     terminal.write('\x1b[s')
-    terminal.write('\x1b['..row..':'..col..'H')
+    terminal.write('\x1b['..row..';'..col..'H')
 end
 
 function terminal.restore_cursor()

--- a/lua/hologram/utils.lua
+++ b/lua/hologram/utils.lua
@@ -4,7 +4,7 @@ local utils = {}
 function utils.buf_screenpos(row, col, win, buf)
     local top = vim.fn.line('w0', win)
     local filler = utils.filler_above(row, win, buf)
-    row = row-top+filler+1
+    row = row - top + filler + 1
     return utils.win_screenpos(row, col, win)
 end
 
@@ -17,18 +17,18 @@ end
 
 function utils.filler_above(row, win, buf)
     local top = vim.fn.line('w0', win)
-    row = row-1 -- row exclusive
+    row = row - 1 -- row exclusive
     if row <= top then
         return 0
     else
         local filler = vim.fn.winsaveview().topfill
         local exts = vim.api.nvim_buf_get_extmarks(buf,
             vim.g.hologram_extmark_ns,
-            {top-1, 0},
-            {row-1, -1},
-            {details=true}
+            {top - 1, 0},
+            {row - 1, -1},
+            {details = true}
         )
-        for i=1,#exts do
+        for i = 1, #exts do
             local opts = exts[i][4]
             if opts.virt_lines then filler = filler + #opts.virt_lines end
         end


### PR DESCRIPTION
The ANSI code for moving cursor is `ESC[{line};{column}H`.

I'm guessing it worked in your terminal cuz it doesn't check the delimiter char, but on konsole this doesn't work