### PR TITLE
Fix markdown relative paths with "./"

### DIFF
--- a/lua/hologram/fs.lua
+++ b/lua/hologram/fs.lua
@@ -43,4 +43,24 @@ function fs.bytes2int(bufp)
     return bor(lsh(bufp[0],24), lsh(bufp[1],16), lsh(bufp[2],8), bufp[3])
 end
 
+function fs.get_absolute_path(path)
+    if fs._is_root_path(path) then
+        return path
+    else
+        local folder_path = vim.fn.expand("%:p:h")
+	local eventual_path = folder_path .. "/" .. path
+        local absolute_path = vim.loop.fs_realpath(eventual_path, nil)
+        return absolute_path
+    end
+end
+
+function fs._is_root_path(path)
+    local first_path_char = string.sub(path, 0, 1)
+    if first_path_char == "/" then
+      return true
+    else
+      return false
+    end
+end
+
 return fs

--- a/lua/hologram/init.lua
+++ b/lua/hologram/init.lua
@@ -108,6 +108,9 @@ function hologram._to_absolute_path(path)
     if hologram._is_root_path(path) then
         return path
     else
+	if hologram._is_dotted_relative_path(path) then
+	    path = string.sub(path, 3)
+        end
         -- absolute_path: folder_path + relative_path
         local folder_path = vim.fn.expand("%:p:h")
         local absolute_path = folder_path .. "/" .. path
@@ -118,6 +121,15 @@ end
 function hologram._is_root_path(path)
     local first_path_char = string.sub(path, 0, 1)
     if first_path_char == "/" then
+      return true
+    else
+      return false
+    end
+end
+
+function hologram._is_dotted_relative_path(path)
+    local first_path_char = string.sub(path, 0, 2)
+    if first_path_char == "./" then
       return true
     else
       return false

--- a/lua/hologram/init.lua
+++ b/lua/hologram/init.lua
@@ -96,43 +96,13 @@ function hologram.find_source(line)
         local inline_link = line:match('!%[.-%]%(.-%)')
         if inline_link then
             local source = inline_link:match('%((.+)%)')
-            local path = hologram._to_absolute_path(source)
-            if fs.check_sig_PNG(path) then
-                return path
+	    local path = fs.get_absolute_path(source)
+	    if path then
+                if fs.check_sig_PNG(path) then
+                    return path
+                else return nil end
             else return nil end
         end
-    end
-end
-
-function hologram._to_absolute_path(path)
-    if hologram._is_root_path(path) then
-        return path
-    else
-	if hologram._is_dotted_relative_path(path) then
-	    path = string.sub(path, 3)
-        end
-        -- absolute_path: folder_path + relative_path
-        local folder_path = vim.fn.expand("%:p:h")
-        local absolute_path = folder_path .. "/" .. path
-        return absolute_path
-    end
-end
-
-function hologram._is_root_path(path)
-    local first_path_char = string.sub(path, 0, 1)
-    if first_path_char == "/" then
-      return true
-    else
-      return false
-    end
-end
-
-function hologram._is_dotted_relative_path(path)
-    local first_path_char = string.sub(path, 0, 2)
-    if first_path_char == "./" then
-      return true
-    else
-      return false
     end
 end
 


### PR DESCRIPTION
Small change to allow for using relative paths starting with `./` for markdown image rendering